### PR TITLE
remove PasteScript & ZopeSkel dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,4 @@ setup(name='zopyx.ipsumplone',
       [z3c.autoinclude.plugin]
       target = plone
       """,
-      setup_requires=["PasteScript"],
-      paster_plugins=["ZopeSkel"],
       )


### PR DESCRIPTION
These pull in quite a few dependencies upon installation of the python egg, but don't get used anywhere in the code.